### PR TITLE
Make node defaults compatible with node 8

### DIFF
--- a/src/main/resources/com/groupon/jenkins/buildtype/install_packages/template/Node/.ci.yml
+++ b/src/main/resources/com/groupon/jenkins/buildtype/install_packages/template/Node/.ci.yml
@@ -34,7 +34,8 @@ build:
   before:
     - trap "rm -rf $TMPDIR" EXIT HUP INT QUIT PIPE TERM
     - mkdir -p $TMPDIR
-    - npm cache clear
+    # npm 5 doesn't support `cache clear`, gracefully ignoring the error that causes
+    - npm cache clear || true
     - npm install
   run:
     - npm test


### PR DESCRIPTION
The current defaults will always fail with node 8 (npm 5).