### PR TITLE
Don't die on npm cache clear failure

### DIFF
--- a/src/main/resources/com/groupon/jenkins/buildtype/install_packages/template/Node/.ci.yml
+++ b/src/main/resources/com/groupon/jenkins/buildtype/install_packages/template/Node/.ci.yml
@@ -34,7 +34,7 @@ build:
   before:
     - trap "rm -rf $TMPDIR" EXIT HUP INT QUIT PIPE TERM
     - mkdir -p $TMPDIR
-    - npm cache clear
+    - npm cache clear || true
     - npm install
   run:
     - npm test


### PR DESCRIPTION
Node v8.x comes with npm 5.x which dies on `npm cache clear`, explaining
that it's unnecessary.  Simplest backward-compatible fix is to just let
it survive that.